### PR TITLE
added shaman lightning rod to whitelist

### DIFF
--- a/KuiSpellList.lua
+++ b/KuiSpellList.lua
@@ -275,6 +275,7 @@ local auras = {
             [17364] = true,  -- stormstrike
             [61882] = true,  -- earthquake
             [188389] = true, -- flame shock
+            [197209] = true, -- lightning rod
         },
         CONTROL = {
             [3600] = true,   -- earthbind totem slow


### PR DESCRIPTION
It would be helpful if you could merge this to have lightning rod in the default whitelist. Thanks for the awesome addon!